### PR TITLE
fix switched active and standby host infos

### DIFF
--- a/controllers/ingress_handler.go
+++ b/controllers/ingress_handler.go
@@ -241,7 +241,7 @@ func (r *HostMigrationReconciler) KubernetesHandler(ctx context.Context, opLog l
 			ingressScheme = "https://"
 		}
 		for _, rule := range ingress.Spec.Rules {
-			activeMigratedIngress = append(activeMigratedIngress, fmt.Sprintf("%s%s", ingressScheme, rule.Host))
+			standbyMigratedIngress = append(standbyMigratedIngress, fmt.Sprintf("%s%s", ingressScheme, rule.Host))
 		}
 	}
 	for _, ingress := range migrateDestinationToSource.Items {
@@ -285,7 +285,7 @@ func (r *HostMigrationReconciler) KubernetesHandler(ctx context.Context, opLog l
 			ingressScheme = "https://"
 		}
 		for _, rule := range ingress.Spec.Rules {
-			standbyMigratedIngress = append(standbyMigratedIngress, fmt.Sprintf("%s%s", ingressScheme, rule.Host))
+			activeMigratedIngress = append(activeMigratedIngress, fmt.Sprintf("%s%s", ingressScheme, rule.Host))
 		}
 	}
 	// wait a sec before updating the ingress

--- a/controllers/route_handler.go
+++ b/controllers/route_handler.go
@@ -119,7 +119,7 @@ func (r *HostMigrationReconciler) OpenshiftHandler(ctx context.Context, opLog lo
 				routeScheme = "https://"
 			}
 		}
-		activeMigratedRoutes = append(activeMigratedRoutes, fmt.Sprintf("%s%s", routeScheme, route.Spec.Host))
+		standbyMigratedRoutes = append(standbyMigratedRoutes, fmt.Sprintf("%s%s", routeScheme, route.Spec.Host))
 	}
 	for _, route := range migrateDestinationToSource.Items {
 		// migrate these routes
@@ -140,7 +140,7 @@ func (r *HostMigrationReconciler) OpenshiftHandler(ctx context.Context, opLog lo
 				routeScheme = "https://"
 			}
 		}
-		standbyMigratedRoutes = append(standbyMigratedRoutes, fmt.Sprintf("%s%s", routeScheme, route.Spec.Host))
+		activeMigratedRoutes = append(activeMigratedRoutes, fmt.Sprintf("%s%s", routeScheme, route.Spec.Host))
 	}
 	// wait a sec before updating the routes
 	checkInterval := time.Duration(1)


### PR DESCRIPTION
during testing of v0.1.8 I realized that the active and standby hosts are switched in the `HostMigration` object after the migration was done, this lead to the issue that the URLs in the lagoon UI where also shown wrong.
After some debugging I realized that there was probably a logic issue in the code, here what I found:

1. we create the `HostMigration` object in the current standby namespace, hence the `source` is the current standby and future active and `destination` is the current active and future standby
2. in the code the part that runs `migrateDestinationToSource` is the part that moves the host from the current active (destination) to the future active (source), but we stored the routes in `standbyMigratedIngress` while it should be stored in `activeMigratedIngress`
3. the code `migrateSourceToDestination` had it exactly switched

I pushed the fix as `amazeeio/dioscuri:v0.1.9rc1` for testing and it seems to work nicely:

here an example before the fix:

```
kind: HostMigration
apiVersion: dioscuri.amazee.io/v1
spec:
  activeEnvironment: drupal-example-test1-controller-master2
  destinationNamespace: drupal-example-test1-controller-master
  hosts:
    activeHosts: 'https://standby.controller.test1.amazee.io'
    standbyHosts: 'https://active.controller.test1.amazee.io'
```

and after the fix 

```
kind: HostMigration
apiVersion: dioscuri.amazee.io/v1
spec:
  activeEnvironment: drupal-example-test1-controller-master
  destinationNamespace: drupal-example-test1-controller-master2
  hosts:
    activeHosts: 'https://active.controller.test1.amazee.io'
    standbyHosts: 'https://standby.controller.test1.amazee.io'
```

